### PR TITLE
make sure that the update git hooks specify gitea

### DIFF
--- a/content/doc/upgrade/from-gogs.en-us.md
+++ b/content/doc/upgrade/from-gogs.en-us.md
@@ -34,6 +34,19 @@ There are some steps to do so below. On Unix run as your Gogs user:
 ### Change gogs specific information:
 
 * Rename `gogs-repositories/` to `gitea-repositories/`
+* Update the update git hook in each repository with:
+```
+cd gitea-repositories
+for user in $(ls); do 
+  for repo in $(ls $user); do 
+    echo instpecting "$PWD/$user/$repo"; 
+    if [ -e "$PWD/$user/$repo/hooks/update" ]; then 
+      echo fixing $PWD/$user/$repo/hooks/update 
+      sed -i 's/gogs/gitea/g' $PWD/$user/$repo/hooks/update 
+    fi
+  done
+done
+```
 * Rename `gogs-data/` to `gitea-data/`
 * In your `gitea/custom/conf/app.ini` change:
 


### PR DESCRIPTION
The update hook that gogs adds to each repository references a path that will no longer exist when migrating to gitea. It's easier to script the text replacement than to edit by hand. This needs translation to other languages.

Even these PR rules are draconian. Please see Pieter Hintjens' C4 protocol and how the 0MQ project operates.
